### PR TITLE
Fixed example URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Command-line client for GitHub's URL shortener.
 
 ## Usage
 
-    $ git.io http://github.com/jgorset/git.io
+    $ git.io https://github.com/jgorset/git.io
     http://git.io/J6MbsQ
 
-    $ git.io http://github.com/jgorset/git.io --code=git.io
+    $ git.io https://github.com/jgorset/git.io --code=git.io
     http://git.io/git.io
 
 ## Installation


### PR DESCRIPTION
Github URLs that are not over HTTPS are considered invalid URLs.

With the examples currently in the README, `git.io: Must be a GitHub.com URL.` is the error given using the first example (`git.io https://github.com/jgorset/git.io`).

This may be confusing to those unfamiliar with the git.io service.